### PR TITLE
Allow merge method to accept null as argument to prevent exception

### DIFF
--- a/src/TailwindRuntime.php
+++ b/src/TailwindRuntime.php
@@ -22,7 +22,7 @@ final class TailwindRuntime implements RuntimeExtensionInterface
         $this->factory = TailwindMerge::factory()->withCache(new Psr16Cache($cache));
     }
 
-    public function merge(string|array $classes, array $configuration = []): string
+    public function merge(string|array|null $classes, array $configuration = []): string
     {
         return $this->factory
             ->withConfiguration($configuration)

--- a/tests/Fixtures/filters/tailwind_merge.test
+++ b/tests/Fixtures/filters/tailwind_merge.test
@@ -5,6 +5,7 @@
 {{ "block inline"|tailwind_merge }}
 {{ classes|tailwind_merge }}
 {{ "tw-text-red-500 tw-text-blue-500"|tailwind_merge({prefix: 'tw-'}) }}
+{{ null|tailwind_merge }}
 --DATA--
 return [
     'classes' => ['h-10', 'h-20'],

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -37,6 +37,6 @@ final class FunctionalTest extends TestCase
     {
         $runtime = new TailwindRuntime();
 
-        $this->assertSame('',$runtime->merge(null));
+        $this->assertSame('', $runtime->merge(null));
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -31,4 +31,12 @@ final class FunctionalTest extends TestCase
 
         $this->assertSame('tw-text-blue-500', $runtime->merge(['tw-text-red-500', 'tw-text-blue-500'], ['prefix' => 'tw-']));
     }
+
+
+    public function testItWillReturnEmptyStringIfSuppliedNull()
+    {
+        $runtime = new TailwindRuntime();
+
+        $this->assertSame('',$runtime->merge(null));
+    }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -32,8 +32,7 @@ final class FunctionalTest extends TestCase
         $this->assertSame('tw-text-blue-500', $runtime->merge(['tw-text-red-500', 'tw-text-blue-500'], ['prefix' => 'tw-']));
     }
 
-
-    public function testItWillReturnEmptyStringIfSuppliedNull()
+    public function testItWillReturnEmptyStringIfSuppliedNull(): void
     {
         $runtime = new TailwindRuntime();
 


### PR DESCRIPTION
This was something I came across while using this filter in conjunction with the Symfony UX Twig Components 
https://symfony.com/bundles/ux-twig-component/current/index.html#cva-and-tailwind-css

I found that if I used the filter like this `attributes.render('class')|tailwind_merge` and `render('class')` ended up returning `null` it results in a crash.

You can work around this by using null coalesce like `attributes.render('class') ?? ''|tailwind_merge` but this feels a bit cumbersome when using it in quite a few places throughout a component.

It feels like simply allowing `null` as an accepted argument type and letting it return an empty string is sensible rather than throwing a type exception.

Would be interested to know your thoughts on this. 🙂 Thanks!
