### PR TITLE
Re-use the same TailwindMerger instance when no custom-configuration is passed

### DIFF
--- a/src/TailwindRuntime.php
+++ b/src/TailwindRuntime.php
@@ -14,6 +14,7 @@ use Twig\Extension\RuntimeExtensionInterface;
 final class TailwindRuntime implements RuntimeExtensionInterface
 {
     private Factory $factory;
+    private TailwindMerge $defaultMerger;
 
     public function __construct(?CacheInterface $cache = null)
     {
@@ -24,6 +25,12 @@ final class TailwindRuntime implements RuntimeExtensionInterface
 
     public function merge(string|array|null $classes, array $configuration = []): string
     {
+        if ([] === $configuration) {
+            $this->defaultMerger ??= $this->factory->make();
+
+            return $this->defaultMerger->merge($classes);
+        }
+
         return $this->factory
             ->withConfiguration($configuration)
             ->make()


### PR DESCRIPTION
99% of the time, I believe you won't pass a custom configuration when calling `tailwind_merge`. 

At the current moment, each time you call `tailwind_merge`, the following code is called and is costly: 
```php
        Config::setAdditionalConfig($this->additionalConfiguration);
        $config = Config::getMergedConfig();

        return new TailwindMerge($config, $this->cache);
```

A simple solution for the majority of use-cases is to re-use the same instance when the configuration is empty. 

For the future, either we store an instance per custom-configuration's hash, either we remove the support of custom configuration at `tailwind_merge` level. 
IMHO, the custom configuration support should be moved at the bundle's configuration, so we will always have one `TailwindMerger` instance across the app.