### PR TITLE
Improve caching speeds by using "cache.system"

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/tailwind.php
+++ b/src/Bridge/Symfony/Bundle/Resources/config/tailwind.php
@@ -11,7 +11,7 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('twig.cache.tailwind')
-            ->parent('cache.app')
+            ->parent('cache.system')
             ->tag('cache.pool', ['name' => 'twig.cache'])
 
         ->set('twig.extension.tailwind', TailwindExtension::class)


### PR DESCRIPTION
_Blackfire profiles are based on the reproducer from https://github.com/symfony/ux/issues/2812, with 50 rows, APP_DEBUG=0 APP_ENV=prod and optimized Composer files_

---

Actually, after many refreshes and TailwindMerger's cache warm-up: https://blackfire.io/profiles/41d1047c-e33d-4849-9c89-f87447875886/graph
<img width="368" alt="image" src="https://github.com/user-attachments/assets/3e149011-63df-406c-abf6-1a99d07bf51b" />

With this PR, 1st request when the TailwindMerger's cache is still cold, we don't see real changes: https://blackfire.io/profiles/bd954d82-ced6-4fd7-a308-11a830d56ca5/graph
<img width="371" alt="image" src="https://github.com/user-attachments/assets/ecd7f868-ab3e-4a6d-8924-ecdf3ee4f636" />

With this PR, next requests, when TailwindMerger's cache is warmed-up: https://blackfire.io/profiles/34e06af9-cf57-46b6-8615-584739de364c/graph
<img width="373" alt="image" src="https://github.com/user-attachments/assets/f0241877-2b50-4d1d-bdd5-164b73f4e797" />

Delta: https://blackfire.io/profiles/compare/383c6e05-0afd-484e-a680-e06ff080383c/graph
<img width="343" alt="image" src="https://github.com/user-attachments/assets/cf693635-c905-424f-98f0-e30cf92a3190" />

---

It works because `cache.system` uses https://symfony.com/doc/current/components/cache/adapters/php_files_adapter.html which is more performant than https://symfony.com/doc/current/components/cache/adapters/filesystem_adapter.html.

However, I'm not sure if that's the recommended way to do so, or if we should create the `PhpArrayAdapter` service ourselves.