### PR TITLE
Improve performances for multiple identical calls to `merge()`, by using `ArrayAdapter` cache

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/tailwind.php
+++ b/src/Bridge/Symfony/Bundle/Resources/config/tailwind.php
@@ -2,11 +2,14 @@
 
 declare(strict_types=1);
 
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use TalesFromADev\Twig\Extra\Tailwind\TailwindExtension;
 use TalesFromADev\Twig\Extra\Tailwind\TailwindRuntime;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container) {
@@ -15,13 +18,20 @@ return static function (ContainerConfigurator $container) {
             ->parent('cache.app')
             ->tag('cache.pool', ['name' => 'twig.cache'])
 
+        ->set('twig.cache.tailwind.chain')
+            ->class(ChainAdapter::class)
+            ->args([[
+                inline_service(ArrayAdapter::class),
+                service('twig.cache.tailwind'),
+            ]])
+
         ->set('twig.extension.tailwind', TailwindExtension::class)
             ->tag('twig.extension')
 
         ->set('twig.runtime.tailwind', TailwindRuntime::class)
             ->args([
                 abstract_arg('additional configuration, set in TalesFromADevTwigExtraTailwindExtension'),
-                service('twig.cache.tailwind'),
+                service('twig.cache.tailwind.chain'),
             ])
             ->tag('twig.runtime')
     ;


### PR DESCRIPTION
While trying to improve TwigComponent performances, I noticed a quick-win on `merge()` by using a `ArrayAdapter` before fallbacking on `FilesystemAdapter`, thanks to the `ChainAdapter`.

The following code is improved by **~70%**, going from **~67,3ms** to **~19.8ms** ([Blackfire profile](https://app.blackfire.io/profiles/compare/f697ee66-299a-439e-a2ba-50c3fccb47fd...9ec25c81-7018-4680-a68a-f5f41228143e/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=focused&settings%5BtabPane%5D=nodes&selected=TalesFromADev%5CTwig%5CExtra%5CTailwind%5CTailwindRuntime%3A%3Amerge&callname=TalesFromADev%5CTwig%5CExtra%5CTailwind%5CTailwindRuntime%3A%3Amerge)):
<img width="444" height="614" alt="image" src="https://github.com/user-attachments/assets/6b07a2ae-6d68-428b-9acb-010827400cd0" />


```twig
<twig:Table>
    <twig:Table:Header>
        <twig:Table:Head class="w-[100px]">#</twig:Table:Head>
        <twig:Table:Head>Status</twig:Table:Head>
        <twig:Table:Head>Method</twig:Table:Head>
        <twig:Table:Head class="text-right">Actions</twig:Table:Head>
    </twig:Table:Header>
    <twig:Table:Body>
        {% for i in 1..25 %}
            <twig:Table:Row>
                <twig:Table:Cell class="font-medium">{{ i }}</twig:Table:Cell>
                <twig:Table:Cell>foo</twig:Table:Cell>
                <twig:Table:Cell>bar</twig:Table:Cell>
                <twig:Table:Cell class="text-right">
                    <twig:Tooltip id="{{ 'id-action-edit-'~i }}">
                        <twig:Tooltip:Trigger>
                            <twig:Button {{ ...trigger_attrs }}>
                                Edit
                            </twig:Button>
                            <twig:Tooltip:Content>
                                Hi!
                                <twig:KbdGroup>
                                    <twig:Kbd>A</twig:Kbd>
                                    <twig:Kbd>B</twig:Kbd>
                                    <twig:Kbd>C</twig:Kbd>
                                </twig:KbdGroup>
                            </twig:Tooltip:Content>
                        </twig:Tooltip:Trigger>
                    </twig:Tooltip>
                    <twig:Tooltip id="{{ 'id-action-delete-'~i }}">
                        <twig:Tooltip:Trigger>
                            <twig:Button variant="destructive" {{ ...trigger_attrs }}>
                                Delete
                            </twig:Button>
                            <twig:Tooltip:Content>
                                Hi!
                                <twig:KbdGroup>
                                    <twig:Kbd>A</twig:Kbd>
                                    <twig:Kbd>B</twig:Kbd>
                                    <twig:Kbd>C</twig:Kbd>
                                </twig:KbdGroup>
                            </twig:Tooltip:Content>
                        </twig:Tooltip:Trigger>
                    </twig:Tooltip>
                </twig:Table:Cell>
            </twig:Table:Row>
        {% endfor %}
    </twig:Table:Body>
    <twig:Table:Footer>
        <twig:Table:Row>
            <twig:Table:Cell colspan="3">Total</twig:Table:Cell>
            <twig:Table:Cell class="text-right">$1,500.00</twig:Table:Cell>
        </twig:Table:Row>
    </twig:Table:Footer>
</twig:Table>
```

_The components can be found at https://github.com/symfony/ux-toolkit/tree/2.x/kits_
