### PR TITLE
use cache.system pool

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/tailwind.php
+++ b/src/Bridge/Symfony/Bundle/Resources/config/tailwind.php
@@ -14,15 +14,15 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
-        ->set('twig.cache.tailwind')
-            ->parent('cache.app')
-            ->tag('cache.pool', ['name' => 'twig.cache'])
+        ->set('cache.twig.tailwind')
+            ->parent('cache.system')
+            ->tag('cache.pool')
 
         ->set('twig.cache.tailwind.chain')
             ->class(ChainAdapter::class)
             ->args([[
                 inline_service(ArrayAdapter::class),
-                service('twig.cache.tailwind'),
+                service('cache.twig.tailwind'),
             ]])
 
         ->set('twig.extension.tailwind', TailwindExtension::class)

--- a/src/Bridge/Symfony/Bundle/Resources/config/tailwind.php
+++ b/src/Bridge/Symfony/Bundle/Resources/config/tailwind.php
@@ -18,20 +18,13 @@ return static function (ContainerConfigurator $container) {
             ->parent('cache.system')
             ->tag('cache.pool')
 
-        ->set('twig.cache.tailwind.chain')
-            ->class(ChainAdapter::class)
-            ->args([[
-                inline_service(ArrayAdapter::class),
-                service('cache.twig.tailwind'),
-            ]])
-
         ->set('twig.extension.tailwind', TailwindExtension::class)
             ->tag('twig.extension')
 
         ->set('twig.runtime.tailwind', TailwindRuntime::class)
             ->args([
                 abstract_arg('additional configuration, set in TalesFromADevTwigExtraTailwindExtension'),
-                service('twig.cache.tailwind.chain'),
+                service('cache.twig.tailwind'),
             ])
             ->tag('twig.runtime')
     ;


### PR DESCRIPTION
since the cache is not related to app business, let's use `cache.system` pool instead (example: https://github.com/symfony/ux/blob/1cc7362/src/TwigComponent/config/cache.php#L19) and use the service name as the cache name

`cache.system` is already a ChainAdapter